### PR TITLE
Fix u8 overflow in xmasRedGreenTwinkles() when NUM_PIXELS >= 256.

### DIFF
--- a/src/arduino_sketch.cpp
+++ b/src/arduino_sketch.cpp
@@ -387,7 +387,7 @@ void xmasRedGreenTwinkles(u16 runSec)
     pixels.setPixelColor(twinkleLedIdx, 0xffffff);
     pixels.show();
     delay(flashOnDelayMs);
-    for (u8 i = 0; i < pixels.numPixels(); ++i) {
+    for (u16 i = 0; i < pixels.numPixels(); ++i) {
       u32 c = (i + redOrGreenFirst) & 1 ? 0xff0000 : 0x00ff00;
       pixels.setPixelColor(i, c);
     }


### PR DESCRIPTION
The for() loop index was a u8 type, so if pixels.numPixels() >= 256,
the index would overflow causing the emulator to hang.  So, increase
index to u16 type to allow for up to 65536 pixels.

Note that the emulator should handle that many pixels but an Arduino
likely won't.